### PR TITLE
Fix missing provider when updating to v2.0.2

### DIFF
--- a/Sources/com.jk.weather.sdPlugin/manifest.json
+++ b/Sources/com.jk.weather.sdPlugin/manifest.json
@@ -23,7 +23,7 @@
   "Icon": "resources/pluginIcon",
   "PropertyInspectorPath": "pi/main_pi.html",
   "URL": "https://github.com/JaouherK",
-  "Version": "2.1.0",
+  "Version": "2.1.1",
   "OS": [
     {
       "Platform": "mac",

--- a/Sources/com.jk.weather.sdPlugin/pi/main_pi.js
+++ b/Sources/com.jk.weather.sdPlugin/pi/main_pi.js
@@ -104,7 +104,7 @@ function openPage(site) {
 }
 
 function getProviderUrl() {
-  const provider = document.getElementById("provider").value;
+  const provider = document.getElementById("provider").value || 'weatherApi';
   let url;
   switch (provider) {
     case "weatherApi":

--- a/Sources/com.jk.weather.sdPlugin/plugin/main.js
+++ b/Sources/com.jk.weather.sdPlugin/plugin/main.js
@@ -65,7 +65,7 @@ function connectElgatoStreamDeckSocket(
         jsonObj.payload.settings.hasOwnProperty("apiKey")
       ) {
         apiKey = jsonObj.payload.settings["apiKey"];
-        provider = jsonObj.payload.settings["provider"];
+        provider = jsonObj.payload.settings["provider"] || 'weatherApi';
       }
     } else if (jsonObj["event"] === "keyDown") {
       const json = {


### PR DESCRIPTION
I did some testing updating between v2.0.2 to v2.1.0 and it seems the "provider" property is missing from the global settings state until it's toggled between providers (after which, it works fine.)

This update would fix all the users who still have bugged weather buttons.

Relates to #5 which is likely affecting most users of this plugin